### PR TITLE
wireguard-tools: call jsonfilter just once

### DIFF
--- a/package/network/utils/wireguard-tools/files/wireguard_watchdog
+++ b/package/network/utils/wireguard-tools/files/wireguard_watchdog
@@ -59,7 +59,7 @@ check_peer_activity() {
 }
 
 # query ubus for all active wireguard interfaces
-wg_ifaces=$(ubus -S call network.interface dump | jsonfilter -e '@.interface[@.up=true]' | jsonfilter -a -e '@[@.proto="wireguard"].interface' | tr "\n" " ")
+wg_ifaces=$(ubus -S call network.interface dump | jsonfilter -e '@.interface[@.up=true && @.proto="wireguard"].interface' | tr "\n" " ")
 
 # check every peer in every active wireguard interface
 config_load network


### PR DESCRIPTION
Eliminate the extra call to jsonfilter to enumerate active WireGuard interfaces to avoid potential bugs and be more efficient.

This change was originally proposed by @pputerla in https://github.com/openwrt/openwrt/pull/11649 as a workaround for https://github.com/openwrt/openwrt/issues/8703. Since 22.03.2 the issue seems to be fixed so @pputerla closed the pull request, but I think it's still very worth it as it is more efficient and robust.